### PR TITLE
Create 5GB dummy file during prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,1 +1,7 @@
 image: drupalpod/drupalpod-gitpod-base:20211128-base-experimental4
+
+tasks:
+  - init: |
+      echo "Creating 5GB dummy file"
+      time fallocate -l 5g 5gb-dummy-file.delete.me
+      echo "Finished creating dummy file"


### PR DESCRIPTION
Open this PR in Gitpod, it will take over 1 minute to open!


Compared to `main` branch of this repo, which only takes 5 seconds to open.

Both `main` and this PR use 340MB custom docker image with 1 layer.

The only difference between the 2?
- This PR adds 5GB dummy file during prebuild.